### PR TITLE
Disable "Edit on GitHub" button for all changelog pages

### DIFF
--- a/10.Mender-server/docs.md
+++ b/10.Mender-server/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## Mender 2.7.0

--- a/20.Mender-client/docs.md
+++ b/20.Mender-client/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender 2.6.0

--- a/21.mender-connect/docs.md
+++ b/21.mender-connect/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender-connect 1.1.0

--- a/22.mender-configure-module/docs.md
+++ b/22.mender-configure-module/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender-configure-module 1.0.0

--- a/30.mender-artifact/docs.md
+++ b/30.mender-artifact/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender-artifact 3.5.1

--- a/31.mender-cli/docs.md
+++ b/31.mender-cli/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender-cli 1.7.0

--- a/32.mender-convert/docs.md
+++ b/32.mender-convert/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender-convert 2.4.0

--- a/40.meta-mender/docs.md
+++ b/40.meta-mender/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## meta-mender dunfell-v2021.06

--- a/50.mender-binary-delta/docs.md
+++ b/50.mender-binary-delta/docs.md
@@ -4,6 +4,7 @@ taxonomy:
     category: docs
 shortcode-core:
     active: false
+github: false
 ---
 
 ## mender-binary-delta 1.2.1


### PR DESCRIPTION
The content is auto-generated. Furthermore the links would point to the
wrong place (mender-docs repository).