### PR TITLE
Mender convert 2.5.2 stats and changelog

### DIFF
--- a/32.mender-convert/docs.md
+++ b/32.mender-convert/docs.md
@@ -96,6 +96,62 @@ New changes in mender-convert since 2.5.0:
     ...
 
 
+## mender-convert 2.5.2
+
+_Released 09.30.2021_
+
+### Statistics
+
+A total of 107 lines added, 38 removed (delta 69)
+
+| Developers with the most changesets | |
+|---|---|
+| Kristian Amlie | 5 (71.4%) |
+| Lluis Campos | 1 (14.3%) |
+| Andrey Basov | 1 (14.3%) |
+
+| Developers with the most changed lines | |
+|---|---|
+| Kristian Amlie | 89 (83.2%) |
+| Lluis Campos | 14 (13.1%) |
+| Andrey Basov | 4 (3.7%) |
+
+| Developers with the most signoffs (total 1) | |
+|---|---|
+| Kristian Amlie | 1 (100.0%) |
+
+| Top changeset contributors by employer | |
+|---|---|
+| Northern.tech | 6 (85.7%) |
+| dev.basov@gmail.com | 1 (14.3%) |
+
+| Top lines changed by employer | |
+|---|---|
+| Northern.tech | 103 (96.3%) |
+| dev.basov@gmail.com | 4 (3.7%) |
+
+| Employers with the most signoffs (total 1) | |
+|---|---|
+| Northern.tech | 1 (100.0%) |
+
+| Employers with the most hackers (total 3) | |
+|---|---|
+| Northern.tech | 2 (66.7%) |
+| dev.basov@gmail.com | 1 (33.3%) |
+
+### Changelogs
+
+## mender-convert 2.5.2
+
+#### mender-convert (2.5.2)
+
+New changes in mender-convert since 2.5.0:
+
+* Closing curly brace added in bootstrap-rootfs-overlay-production-server.sh
+* Fix broken download of packages when `*_VERSION` are set to
+  `master`.
+
+
 ## mender-convert 2.5.1
 
 _Released 09.30.2021_

--- a/32.mender-convert/docs.md
+++ b/32.mender-convert/docs.md
@@ -100,71 +100,7 @@ New changes in mender-convert since 2.5.0:
 
 _Released 09.30.2021_
 
-### Statistics
-
-A total of 181 lines added, 81 removed (delta 100)
-
-| Developers with the most changesets | |
-|---|---|
-| Kristian Amlie | 7 (43.8%) |
-| Ole Petter Orhagen | 5 (31.2%) |
-| Lluis Campos | 4 (25.0%) |
-
-| Developers with the most changed lines | |
-|---|---|
-| Kristian Amlie | 91 (48.9%) |
-| Lluis Campos | 70 (37.6%) |
-| Ole Petter Orhagen | 25 (13.4%) |
-
-| Top changeset contributors by employer | |
-|---|---|
-| Northern.tech | 16 (100.0%) |
-
-| Top lines changed by employer | |
-|---|---|
-| Northern.tech | 186 (100.0%) |
-
-| Employers with the most hackers (total 3) | |
-|---|---|
-| Northern.tech | 3 (100.0%) |
-
-
-#### Changelogs
-
-New changes in mender-convert since 2.5.0:
-
-* configs/images/raspberrypi_raspbian_config: Allow APT Suite change
-  ([MEN-5057](https://tracker.mender.io/browse/MEN-5057))
-* Fix broken download of packages when `*_VERSION` are set to
-  `master`.
-* grub-mender-grubenv: User space tools, "fw_printenv" and
-  "fw_setenv" have been renamed to "grub-mender-grubenv-print" and
-  "grub-mender-grubenv-set", respectively. This has been done in order
-  to avoid conflict with U-Boot's user space tools, which have the same
-  names.
-* RPi pre-converted images: remove Mender client version from
-  Artifact name.
-* Aggregated Dependabot Changelogs:
-  * Bumps [jsdom](https://github.com/jsdom/jsdom) from 16.6.0 to 16.7.0.
-    - [Release notes](https://github.com/jsdom/jsdom/releases)
-    - [Changelog](https://github.com/jsdom/jsdom/blob/master/Changelog.md)
-    - [Commits](https://github.com/jsdom/jsdom/compare/16.6.0...16.7.0)
-    ---
-    updated-dependencies:
-    - dependency-name: jsdom
-      dependency-type: direct:production
-      update-type: version-update:semver-minor
-    ...
-  * Bumps [jsdom](https://github.com/jsdom/jsdom) from 16.7.0 to 17.0.0.
-    - [Release notes](https://github.com/jsdom/jsdom/releases)
-    - [Changelog](https://github.com/jsdom/jsdom/blob/master/Changelog.md)
-    - [Commits](https://github.com/jsdom/jsdom/compare/16.7.0...17.0.0)
-    ---
-    updated-dependencies:
-    - dependency-name: jsdom
-      dependency-type: direct:production
-      update-type: version-update:semver-major
-    ...
+    mender-convert 2.5.1 was a faulty release, and has been removed.
 
 
 ## mender-convert 2.5.0

--- a/32.mender-convert/docs.md
+++ b/32.mender-convert/docs.md
@@ -96,6 +96,77 @@ New changes in mender-convert since 2.5.0:
     ...
 
 
+## mender-convert 2.5.1
+
+_Released 09.30.2021_
+
+### Statistics
+
+A total of 181 lines added, 81 removed (delta 100)
+
+| Developers with the most changesets | |
+|---|---|
+| Kristian Amlie | 7 (43.8%) |
+| Ole Petter Orhagen | 5 (31.2%) |
+| Lluis Campos | 4 (25.0%) |
+
+| Developers with the most changed lines | |
+|---|---|
+| Kristian Amlie | 91 (48.9%) |
+| Lluis Campos | 70 (37.6%) |
+| Ole Petter Orhagen | 25 (13.4%) |
+
+| Top changeset contributors by employer | |
+|---|---|
+| Northern.tech | 16 (100.0%) |
+
+| Top lines changed by employer | |
+|---|---|
+| Northern.tech | 186 (100.0%) |
+
+| Employers with the most hackers (total 3) | |
+|---|---|
+| Northern.tech | 3 (100.0%) |
+
+
+#### Changelogs
+
+New changes in mender-convert since 2.5.0:
+
+* configs/images/raspberrypi_raspbian_config: Allow APT Suite change
+  ([MEN-5057](https://tracker.mender.io/browse/MEN-5057))
+* Fix broken download of packages when `*_VERSION` are set to
+  `master`.
+* grub-mender-grubenv: User space tools, "fw_printenv" and
+  "fw_setenv" have been renamed to "grub-mender-grubenv-print" and
+  "grub-mender-grubenv-set", respectively. This has been done in order
+  to avoid conflict with U-Boot's user space tools, which have the same
+  names.
+* RPi pre-converted images: remove Mender client version from
+  Artifact name.
+* Aggregated Dependabot Changelogs:
+  * Bumps [jsdom](https://github.com/jsdom/jsdom) from 16.6.0 to 16.7.0.
+    - [Release notes](https://github.com/jsdom/jsdom/releases)
+    - [Changelog](https://github.com/jsdom/jsdom/blob/master/Changelog.md)
+    - [Commits](https://github.com/jsdom/jsdom/compare/16.6.0...16.7.0)
+    ---
+    updated-dependencies:
+    - dependency-name: jsdom
+      dependency-type: direct:production
+      update-type: version-update:semver-minor
+    ...
+  * Bumps [jsdom](https://github.com/jsdom/jsdom) from 16.7.0 to 17.0.0.
+    - [Release notes](https://github.com/jsdom/jsdom/releases)
+    - [Changelog](https://github.com/jsdom/jsdom/blob/master/Changelog.md)
+    - [Commits](https://github.com/jsdom/jsdom/compare/16.7.0...17.0.0)
+    ---
+    updated-dependencies:
+    - dependency-name: jsdom
+      dependency-type: direct:production
+      update-type: version-update:semver-major
+    ...
+
+
 ## mender-convert 2.5.0
 
 _Released 07.14.2021_


### PR DESCRIPTION
Follow up from: https://github.com/mendersoftware/mender-docs-changelog/pull/13