### PR TITLE
chore: Add 1.0.0 changelog for mender-mcu

### DIFF
--- a/80.mender-mcu/docs.md
+++ b/80.mender-mcu/docs.md
@@ -6,7 +6,6 @@ shortcode-core:
     active: false
 github: false
 ---
-## 0.9.0 - 2025-04-11
+## 1.0.0 - 2026-04-20
 
-* Preview of Mender MCU
-
+* The first stable release


### PR DESCRIPTION
It wasn't published by the automation due to an error in the tagged release pipeline.